### PR TITLE
Removed Magic Strings from router, and routes

### DIFF
--- a/SwiftHTTPServer.xcodeproj/project.pbxproj
+++ b/SwiftHTTPServer.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		E29B29F01CCE60DB00D60B87 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29B29EE1CCE60DB00D60B87 /* Router.swift */; };
 		E29B29F41CCE61A400D60B87 /* RouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29B29F31CCE61A400D60B87 /* RouterTests.swift */; };
 		E29B938C1CC83907008AEED5 /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29B938B1CC83907008AEED5 /* ResponseTests.swift */; };
+		E2CCD06D1D008F3700BE4E1E /* HTTPMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CCD06C1D008F3700BE4E1E /* HTTPMethods.swift */; };
+		E2CCD06E1D008F3700BE4E1E /* HTTPMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CCD06C1D008F3700BE4E1E /* HTTPMethods.swift */; };
 		E2D9C1291CC7CF3900B7B5CB /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D9C1281CC7CF3900B7B5CB /* Request.swift */; };
 		E2D9C12A1CC7CF3900B7B5CB /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D9C1281CC7CF3900B7B5CB /* Request.swift */; };
 		E2D9C12F1CC7D08F00B7B5CB /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D9C12E1CC7D08F00B7B5CB /* RequestTests.swift */; };
@@ -99,6 +101,7 @@
 		E29B29EE1CCE60DB00D60B87 /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		E29B29F31CCE61A400D60B87 /* RouterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouterTests.swift; sourceTree = "<group>"; };
 		E29B938B1CC83907008AEED5 /* ResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseTests.swift; sourceTree = "<group>"; };
+		E2CCD06C1D008F3700BE4E1E /* HTTPMethods.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPMethods.swift; sourceTree = "<group>"; };
 		E2D9C1281CC7CF3900B7B5CB /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		E2D9C12E1CC7D08F00B7B5CB /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
 		E2DEF4851CEF419F00E4A274 /* BasicAuthRoute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicAuthRoute.swift; sourceTree = "<group>"; };
@@ -189,6 +192,7 @@
 				E24251631CEE184400F164AA /* FileOperations.swift */,
 				E24251681CEF3E7F00F164AA /* Logger.swift */,
 				E2DEF4851CEF419F00E4A274 /* BasicAuthRoute.swift */,
+				E2CCD06C1D008F3700BE4E1E /* HTTPMethods.swift */,
 			);
 			path = SwiftHTTPServer;
 			sourceTree = "<group>";
@@ -309,6 +313,7 @@
 			files = (
 				E2E92FBB1CC68701003C2757 /* HTTPResponseGenerator.swift in Sources */,
 				E2D9C1291CC7CF3900B7B5CB /* Request.swift in Sources */,
+				E2CCD06D1D008F3700BE4E1E /* HTTPMethods.swift in Sources */,
 				E2E2D0551CE3804900C3BE34 /* FileServingRoute.swift in Sources */,
 				E267CD751CD00F6B001AB593 /* Route.swift in Sources */,
 				E24251691CEF3E7F00F164AA /* Logger.swift in Sources */,
@@ -336,6 +341,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E2CCD06E1D008F3700BE4E1E /* HTTPMethods.swift in Sources */,
 				E2F5C8A21CD247AC00793B5C /* BasicRouteTests.swift in Sources */,
 				E24188BC1CD7D83F009884A3 /* RedirectRouteTests.swift in Sources */,
 				E29B29EB1CCA841200D60B87 /* SwiftSocket.swift in Sources */,

--- a/SwiftHTTPServer.xcodeproj/project.pbxproj
+++ b/SwiftHTTPServer.xcodeproj/project.pbxproj
@@ -34,6 +34,9 @@
 		E29B938C1CC83907008AEED5 /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29B938B1CC83907008AEED5 /* ResponseTests.swift */; };
 		E2CCD06D1D008F3700BE4E1E /* HTTPMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CCD06C1D008F3700BE4E1E /* HTTPMethods.swift */; };
 		E2CCD06E1D008F3700BE4E1E /* HTTPMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CCD06C1D008F3700BE4E1E /* HTTPMethods.swift */; };
+		E2CCD0701D00C80E00BE4E1E /* NotAllowedRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CCD06F1D00C80E00BE4E1E /* NotAllowedRoute.swift */; };
+		E2CCD0711D00C80E00BE4E1E /* NotAllowedRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CCD06F1D00C80E00BE4E1E /* NotAllowedRoute.swift */; };
+		E2CCD0731D00C94300BE4E1E /* NotAllowedRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CCD0721D00C94300BE4E1E /* NotAllowedRouteTests.swift */; };
 		E2D9C1291CC7CF3900B7B5CB /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D9C1281CC7CF3900B7B5CB /* Request.swift */; };
 		E2D9C12A1CC7CF3900B7B5CB /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D9C1281CC7CF3900B7B5CB /* Request.swift */; };
 		E2D9C12F1CC7D08F00B7B5CB /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D9C12E1CC7D08F00B7B5CB /* RequestTests.swift */; };
@@ -102,6 +105,8 @@
 		E29B29F31CCE61A400D60B87 /* RouterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouterTests.swift; sourceTree = "<group>"; };
 		E29B938B1CC83907008AEED5 /* ResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseTests.swift; sourceTree = "<group>"; };
 		E2CCD06C1D008F3700BE4E1E /* HTTPMethods.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPMethods.swift; sourceTree = "<group>"; };
+		E2CCD06F1D00C80E00BE4E1E /* NotAllowedRoute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotAllowedRoute.swift; sourceTree = "<group>"; };
+		E2CCD0721D00C94300BE4E1E /* NotAllowedRouteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotAllowedRouteTests.swift; sourceTree = "<group>"; };
 		E2D9C1281CC7CF3900B7B5CB /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		E2D9C12E1CC7D08F00B7B5CB /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
 		E2DEF4851CEF419F00E4A274 /* BasicAuthRoute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicAuthRoute.swift; sourceTree = "<group>"; };
@@ -193,6 +198,7 @@
 				E24251681CEF3E7F00F164AA /* Logger.swift */,
 				E2DEF4851CEF419F00E4A274 /* BasicAuthRoute.swift */,
 				E2CCD06C1D008F3700BE4E1E /* HTTPMethods.swift */,
+				E2CCD06F1D00C80E00BE4E1E /* NotAllowedRoute.swift */,
 			);
 			path = SwiftHTTPServer;
 			sourceTree = "<group>";
@@ -219,6 +225,7 @@
 				E24251661CEE1CEC00F164AA /* FileOperationsTests.swift */,
 				E2DEF4881CF34B5600E4A274 /* BasicAuthRouteTests.swift */,
 				E2DEF48A1CF35A1C00E4A274 /* LoggerTests.swift */,
+				E2CCD0721D00C94300BE4E1E /* NotAllowedRouteTests.swift */,
 			);
 			path = SwiftHTTPServerTests;
 			sourceTree = "<group>";
@@ -311,6 +318,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E2CCD0701D00C80E00BE4E1E /* NotAllowedRoute.swift in Sources */,
 				E2E92FBB1CC68701003C2757 /* HTTPResponseGenerator.swift in Sources */,
 				E2D9C1291CC7CF3900B7B5CB /* Request.swift in Sources */,
 				E2CCD06D1D008F3700BE4E1E /* HTTPMethods.swift in Sources */,
@@ -369,6 +377,7 @@
 				E2DEF4871CEF419F00E4A274 /* BasicAuthRoute.swift in Sources */,
 				E2E2D0501CDBAA5300C3BE34 /* DictionaryDefaultValueTests.swift in Sources */,
 				E242515F1CEDE17800F164AA /* FileServingRouteTests.swift in Sources */,
+				E2CCD0731D00C94300BE4E1E /* NotAllowedRouteTests.swift in Sources */,
 				E2DEF4891CF34B5600E4A274 /* BasicAuthRouteTests.swift in Sources */,
 				E29B29F41CCE61A400D60B87 /* RouterTests.swift in Sources */,
 				E2E15EBC1CC53D040054DA4F /* HTTPResponseHandler.swift in Sources */,
@@ -380,6 +389,7 @@
 				E2F5C8BB1CD282A200793B5C /* HTTPResponseHandlerTests.swift in Sources */,
 				E2F5C8A71CD2590E00793B5C /* NotFoundRouteTests.swift in Sources */,
 				E267CD701CCFADE6001AB593 /* ParameterDecoderTests.swift in Sources */,
+				E2CCD0711D00C80E00BE4E1E /* NotAllowedRoute.swift in Sources */,
 				E24188BA1CD7D691009884A3 /* RedirectRoute.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftHTTPServer/BasicAuthRoute.swift
+++ b/SwiftHTTPServer/BasicAuthRoute.swift
@@ -6,7 +6,7 @@ class BasicAuthRoute: BasicRoute {
     
     var statusCode = "200"
     
-    override func getResponseBody(uri: String, method: String, requestHeaders: Dictionary<String, String>, requestBody: String?) -> [UInt8] {
+    override func getResponseBody(uri: String, method: HTTPMethods, requestHeaders: Dictionary<String, String>, requestBody: String?) -> [UInt8] {
         var content = [UInt8]()
         let authorized = getAuthorized(requestHeaders: requestHeaders)
         
@@ -20,7 +20,7 @@ class BasicAuthRoute: BasicRoute {
         return content
     }
     
-    override func getResponseHeaders(uri: String, method: String, requestBody: String?) -> Dictionary<String, String> {
+    override func getResponseHeaders(uri: String, method: HTTPMethods, requestBody: String?) -> Dictionary<String, String> {
         var headers = Dictionary<String,String>()
         if (statusCode != "200"){
             headers["WWW-Authenticate"] =  "Basic realm=\"Naperville\""
@@ -28,7 +28,7 @@ class BasicAuthRoute: BasicRoute {
         return headers
     }
     
-    override func getResponseStatusCode(method: String) -> String {
+    override func getResponseStatusCode(method: HTTPMethods) -> String {
         return statusCode
     }
     

--- a/SwiftHTTPServer/BasicRoute.swift
+++ b/SwiftHTTPServer/BasicRoute.swift
@@ -13,26 +13,26 @@ class BasicRoute: Route {
         return allowedMethods
     }
     
-    func isAllowedMethod(method: String) -> Bool {
+    func isAllowedMethod(method: HTTPMethods) -> Bool {
         return contains(allowedMethods: getAllowedMethods(), method: method)
     }
     
-    func getResponseBody(uri: String, method: String, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8] {
-        let bodyString: String = isAllowedMethod(method: method) ? "\(method) for \(uri)" : "405 - Method Not Allowed"
+    func getResponseBody(uri: String, method: HTTPMethods, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8] {
+        let bodyString: String = isAllowedMethod(method: method) ? "\(method.rawValue) for \(uri)" : "405 - Method Not Allowed"
         return removeNullBytes(byteArray: getByteArrayFromString(string: bodyString))
     }
     
-    func getResponseHeaders(uri: String, method: String, requestBody: String?) -> Dictionary<String,String> {
+    func getResponseHeaders(uri: String, method: HTTPMethods, requestBody: String?) -> Dictionary<String,String> {
         var headers : Dictionary<String,String> = Dictionary<String,String>()
 
         headers["Content-Type"] = "text/html"
-        if (method == "OPTIONS") {
+        if (method == .Options) {
             headers["Allow"] = joined(allowedMethods: allowedMethods, separator: ",")
         }
         return headers
     }
     
-    func getResponseStatusCode(method: String) -> String {
+    func getResponseStatusCode(method: HTTPMethods) -> String {
         let statusCode: String = isAllowedMethod(method: method) ? "200" : "405"
         return statusCode
     }
@@ -58,25 +58,21 @@ class BasicRoute: Route {
         return myArray
     }
     
-    func contains(allowedMethods: [HTTPMethods], method: String) -> Bool{
-        for httpMethod in allowedMethods {
-            if (httpMethod.rawValue == method)
-            {
-                return true
-            }
+    func contains(allowedMethods: [HTTPMethods], method: HTTPMethods) -> Bool {
+        return allowedMethods.contains { ele in
+            ele.rawValue == method.rawValue
         }
-        return false
     }
     
     func joined(allowedMethods: [HTTPMethods], separator: String) -> String {
         var string = ""
         var count = 0
         for method in allowedMethods {
+            count = count + 1
             string += method.rawValue
-            if (count != allowedMethods.count - 1) {
+            if (count != allowedMethods.count) {
                 string += separator
             }
-            count = count + 1
         }
         
         return string

--- a/SwiftHTTPServer/BasicRoute.swift
+++ b/SwiftHTTPServer/BasicRoute.swift
@@ -74,7 +74,7 @@ class BasicRoute: Route {
         for method in allowedMethods {
             string += method.rawValue
             if (count != allowedMethods.count - 1) {
-                string += separator + " "
+                string += separator
             }
             count = count + 1
         }

--- a/SwiftHTTPServer/BasicRoute.swift
+++ b/SwiftHTTPServer/BasicRoute.swift
@@ -2,19 +2,19 @@ import Foundation
 
 class BasicRoute: Route {
     
-    var allowedMethods: [String]?
+    var allowedMethods: [HTTPMethods]
     var contentLength = 0
     
-    required init(allowedMethods: String) {
-        self.allowedMethods = allowedMethods.components(separatedBy: ",")
+    required init(allowedMethods: [HTTPMethods]) {
+        self.allowedMethods = allowedMethods
     }
     
-    func getAllowedMethods() -> [String]{
-        return allowedMethods!
+    func getAllowedMethods() -> [HTTPMethods]{
+        return allowedMethods
     }
     
     func isAllowedMethod(method: String) -> Bool {
-        return getAllowedMethods().contains(method)
+        return contains(allowedMethods: getAllowedMethods(), method: method)
     }
     
     func getResponseBody(uri: String, method: String, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8] {
@@ -27,7 +27,7 @@ class BasicRoute: Route {
 
         headers["Content-Type"] = "text/html"
         if (method == "OPTIONS") {
-            headers["Allow"] = allowedMethods!.joined(separator: ",")
+            headers["Allow"] = joined(allowedMethods: allowedMethods, separator: ",")
         }
         return headers
     }
@@ -56,6 +56,30 @@ class BasicRoute: Route {
             myArray.append(UInt8(char))
         }
         return myArray
+    }
+    
+    func contains(allowedMethods: [HTTPMethods], method: String) -> Bool{
+        for httpMethod in allowedMethods {
+            if (httpMethod.rawValue == method)
+            {
+                return true
+            }
+        }
+        return false
+    }
+    
+    func joined(allowedMethods: [HTTPMethods], separator: String) -> String {
+        var string = ""
+        var count = 0
+        for method in allowedMethods {
+            string += method.rawValue
+            if (count != allowedMethods.count - 1) {
+                string += separator + " "
+            }
+            count = count + 1
+        }
+        
+        return string
     }
     
 }

--- a/SwiftHTTPServer/DirectoryListRoute.swift
+++ b/SwiftHTTPServer/DirectoryListRoute.swift
@@ -6,7 +6,7 @@
 
 class DirectoryListRoute: BasicRoute {
     
-    override func getResponseBody(uri: String, method: String, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8] {
+    override func getResponseBody(uri: String, method: HTTPMethods, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8] {
         let files = DirectoryListRoute.getFilesArray(publicDir: Configuration.publicDirectory)
         var htmlBody: String = "<!DOCTYPE html> <html> <body> <ul>"
         

--- a/SwiftHTTPServer/FileOperations.swift
+++ b/SwiftHTTPServer/FileOperations.swift
@@ -15,11 +15,11 @@ class FileOperations {
         
     }
     
-    func formAction(method: String, body: String?) {
-        if (method == "POST" || method == "PUT") {
+    func formAction(method: HTTPMethods, body: String?) {
+        if (method == .Post || method == .Put) {
             Write(string: body!)
         }
-        else if (method == "DELETE") {
+        else if (method == .Delete) {
             Delete()
         }
     }

--- a/SwiftHTTPServer/FileServingRoute.swift
+++ b/SwiftHTTPServer/FileServingRoute.swift
@@ -2,10 +2,10 @@ class FileServingRoute: BasicRoute {
     
     var statusCode = "200"
     var eTag: String? = nil
-    override func getResponseBody(uri: String, method: String, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8] {
+    override func getResponseBody(uri: String, method: HTTPMethods, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8] {
         let fileOperations = FileOperations(file: uri, pathToDir: Configuration.publicDirectory)
         let contents: [UInt8]
-        if (method == "GET") {
+        if (method == .Get) {
             let range = requestHeaders.get(key: "Range", defaultValue: "")
             
             if (range == "") {
@@ -13,7 +13,7 @@ class FileServingRoute: BasicRoute {
             } else {
                 contents = getPartialContent(fileOperations: fileOperations, range: range)
             }
-        } else if (method == "PATCH") {
+        } else if (method == .Patch) {
             statusCode = "204"
             fileOperations.Write(string: requestBody!)
             eTag = requestHeaders.get(key: "If-Match", defaultValue: "")
@@ -24,18 +24,18 @@ class FileServingRoute: BasicRoute {
         return contents
     }
     
-    override func getResponseHeaders(uri: String, method: String, requestBody: String?) -> Dictionary<String,String> {
+    override func getResponseHeaders(uri: String, method: HTTPMethods, requestBody: String?) -> Dictionary<String,String> {
         var headers : Dictionary<String,String> = Dictionary<String,String>()
-        if (method == "PATCH"){
+        if (method == .Patch){
             headers["ETag"] = eTag!
         }
-        if (method == "OPTIONS") {
+        if (method == .Options) {
             headers["Allow"] = joined(allowedMethods: allowedMethods, separator: ",")
         }
         return headers
     }
     
-    override func getResponseStatusCode(method: String) -> String {
+    override func getResponseStatusCode(method: HTTPMethods) -> String {
         if (isAllowedMethod(method: method)){
             return statusCode
         } else {

--- a/SwiftHTTPServer/FileServingRoute.swift
+++ b/SwiftHTTPServer/FileServingRoute.swift
@@ -30,7 +30,7 @@ class FileServingRoute: BasicRoute {
             headers["ETag"] = eTag!
         }
         if (method == "OPTIONS") {
-            headers["Allow"] = allowedMethods!.joined(separator: ",")
+            headers["Allow"] = joined(allowedMethods: allowedMethods, separator: ",")
         }
         return headers
     }

--- a/SwiftHTTPServer/FormRoute.swift
+++ b/SwiftHTTPServer/FormRoute.swift
@@ -1,12 +1,12 @@
 class FormRoute: BasicRoute {
     
-    override func getResponseBody(uri: String, method: String, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8] {
+    override func getResponseBody(uri: String, method: HTTPMethods, requestHeaders: Dictionary<String, String>, requestBody: String?) -> [UInt8] {
         let formData = FileOperations(file: "/form.txt", pathToDir: ".")
         var formBody = [UInt8]()
         if (isAllowedMethod(method: method)) {
-            if ((method == "POST" || method == "PUT" || method == "DELETE")) {
+            if ((method == .Post || method == .Put || method == .Delete)) {
                 formData.formAction(method: method, body: requestBody!)
-            } else if (method == "GET") {
+            } else if (method == .Get) {
                 formBody = formData.Read()
             }
         } else {

--- a/SwiftHTTPServer/HTTPMethods.swift
+++ b/SwiftHTTPServer/HTTPMethods.swift
@@ -1,0 +1,10 @@
+enum HTTPMethods: String {
+    case Get = "GET"
+    case Head = "HEAD"
+    case Options = "OPTIONS"
+    case Post = "POST"
+    case Patch = "PATCH"
+    case Put = "PUT"
+    case Delete = "DELETE"
+    case Redirect = "REDIRECT"
+}

--- a/SwiftHTTPServer/HTTPMethods.swift
+++ b/SwiftHTTPServer/HTTPMethods.swift
@@ -7,4 +7,5 @@ enum HTTPMethods: String {
     case Put = "PUT"
     case Delete = "DELETE"
     case Redirect = "REDIRECT"
+    case NotAllowed = "Not Allowed"
 }

--- a/SwiftHTTPServer/HTTPResponseGenerator.swift
+++ b/SwiftHTTPServer/HTTPResponseGenerator.swift
@@ -1,6 +1,6 @@
 class HTTPResponseGenerator {
 
-    func generateResponse(URI : String?, baseURI: String, method : String, body : String?, requestHeaders: Dictionary<String, String> ) -> [UInt8] {
+    func generateResponse(URI : String?, baseURI: String, method : HTTPMethods, body : String?, requestHeaders: Dictionary<String, String> ) -> [UInt8] {
         let router = Router(uri: baseURI, method: method, body: body)
         router.initializeRouterDict()
         let route = router.getRoute()

--- a/SwiftHTTPServer/HTTPResponseHandler.swift
+++ b/SwiftHTTPServer/HTTPResponseHandler.swift
@@ -4,7 +4,7 @@ class HTTPResponseHandler: NSObject {
     
     func getResponse(request: Request) -> [UInt8] {
         let responseGenerator = HTTPResponseGenerator()
-        let response = responseGenerator.generateResponse(URI: request.URI, baseURI: request.baseURI!, method: request.method, body: request.body, requestHeaders: request.headerDictionary!)
+        let response = responseGenerator.generateResponse(URI: request.URI, baseURI: request.baseURI!, method: request.method!, body: request.body, requestHeaders: request.headerDictionary!)
         let responseString = response
         return responseString
     }

--- a/SwiftHTTPServer/NotAllowedRoute.swift
+++ b/SwiftHTTPServer/NotAllowedRoute.swift
@@ -1,11 +1,11 @@
-class NotFoundRoute: BasicRoute {
+class NotAllowedRoute: BasicRoute {
     override func getResponseBody(uri: String, method: HTTPMethods, requestHeaders: Dictionary<String, String>, requestBody: String?) -> [UInt8] {
-        return removeNullBytes(byteArray: getByteArrayFromString(string: "404 - Not Found"))
-
+        return removeNullBytes(byteArray: getByteArrayFromString(string: "405 - Method Not Allowed"))
+        
     }
     
     override func getResponseStatusCode(method: HTTPMethods) -> String {
-        return "404"
+        return "405"
     }
     
 }

--- a/SwiftHTTPServer/ParameterRoute.swift
+++ b/SwiftHTTPServer/ParameterRoute.swift
@@ -1,5 +1,5 @@
 class ParameterRoute: BasicRoute {
-    override func getResponseBody(uri: String, method: String, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8] {
+    override func getResponseBody(uri: String, method: HTTPMethods, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8] {
         let parameterDecoder = ParameterDecoder(uri: uri)
         
         return removeNullBytes(byteArray: getByteArrayFromString(string: parameterDecoder.getDecodedParameters()))

--- a/SwiftHTTPServer/RedirectRoute.swift
+++ b/SwiftHTTPServer/RedirectRoute.swift
@@ -8,7 +8,7 @@ class RedirectRoute: BasicRoute {
         var headers : Dictionary<String,String> = Dictionary<String,String>()
         headers["Location"] = "http://localhost:5000/"
         if (method == "OPTIONS") {
-            headers["Allow"] = allowedMethods!.joined(separator: ",")
+            headers["Allow"] = joined(allowedMethods: allowedMethods, separator: ",")
         }
         
         return headers

--- a/SwiftHTTPServer/RedirectRoute.swift
+++ b/SwiftHTTPServer/RedirectRoute.swift
@@ -1,13 +1,13 @@
 class RedirectRoute: BasicRoute {
     
-    override func getResponseStatusCode(method: String) -> String {
+    override func getResponseStatusCode(method: HTTPMethods) -> String {
         return "302"
     }
     
-    override func getResponseHeaders(uri: String, method: String, requestBody: String?) -> Dictionary<String,String> {
+    override func getResponseHeaders(uri: String, method: HTTPMethods, requestBody: String?) -> Dictionary<String,String> {
         var headers : Dictionary<String,String> = Dictionary<String,String>()
         headers["Location"] = "http://localhost:5000/"
-        if (method == "OPTIONS") {
+        if (method == .Options) {
             headers["Allow"] = joined(allowedMethods: allowedMethods, separator: ",")
         }
         

--- a/SwiftHTTPServer/Request.swift
+++ b/SwiftHTTPServer/Request.swift
@@ -1,6 +1,6 @@
 class Request{
     
-    var method = ""
+    var method: HTTPMethods?
     var statusLine = ""
     var URI : String? = ""
     var body: String?
@@ -10,8 +10,7 @@ class Request{
     init(requestString : String) {
         let head = getHead(requestString: requestString)
         statusLine = getStatusLine(head: head)
-        
-        method = getMethod(statusLine: statusLine)
+        method = (HTTPMethods(rawValue: getMethod(statusLine: statusLine))) ?? .NotAllowed
         URI = getURI(statusLine: statusLine)
         let splitURI = split(string: URI!, separator: "?")
         if (splitURI.count > 1) {

--- a/SwiftHTTPServer/Route.swift
+++ b/SwiftHTTPServer/Route.swift
@@ -3,9 +3,9 @@ protocol Route {
     var allowedMethods: [HTTPMethods] {get}
     init(allowedMethods: [HTTPMethods])
     func getAllowedMethods() -> [HTTPMethods]
-    func getResponseHeaders(uri: String, method: String, requestBody: String?) -> Dictionary<String,String>
-    func getResponseBody(uri: String, method: String, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8]
-    func getResponseStatusCode(method: String) -> String
-    func isAllowedMethod(method: String) -> Bool
+    func getResponseHeaders(uri: String, method: HTTPMethods, requestBody: String?) -> Dictionary<String,String>
+    func getResponseBody(uri: String, method: HTTPMethods, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8]
+    func getResponseStatusCode(method: HTTPMethods) -> String
+    func isAllowedMethod(method: HTTPMethods) -> Bool
 }
 

--- a/SwiftHTTPServer/Route.swift
+++ b/SwiftHTTPServer/Route.swift
@@ -1,10 +1,11 @@
 protocol Route {
 
-    var allowedMethods: [String]? {get}
-    init(allowedMethods: String)
-    func getAllowedMethods() -> [String]
+    var allowedMethods: [HTTPMethods] {get}
+    init(allowedMethods: [HTTPMethods])
+    func getAllowedMethods() -> [HTTPMethods]
     func getResponseHeaders(uri: String, method: String, requestBody: String?) -> Dictionary<String,String>
     func getResponseBody(uri: String, method: String, requestHeaders: Dictionary<String,String>, requestBody: String?) -> [UInt8]
     func getResponseStatusCode(method: String) -> String
     func isAllowedMethod(method: String) -> Bool
 }
+

--- a/SwiftHTTPServer/Router.swift
+++ b/SwiftHTTPServer/Router.swift
@@ -1,10 +1,13 @@
 class Router {
-    var uri: String?
+    var uri: String
+    var method: HTTPMethods
     var uriTypeDict = Dictionary<String,Route>()
     var routeNotFound = NotFoundRoute(allowedMethods: [.Get, .Options])
+    var methodNotAllowedRoute = NotAllowedRoute(allowedMethods: [.Get])
     
-    init(uri: String, method: String,body: String?) {
+    init(uri: String, method: HTTPMethods,body: String?) {
         self.uri = uri
+        self.method = method
     }
     
     func initializeRouterDict() {
@@ -22,7 +25,11 @@ class Router {
     }
     
     func getRoute() -> Route {
-        return uriTypeDict.get(key: uri!,defaultValue: routeNotFound)
+        if (method == .NotAllowed) {
+            return methodNotAllowedRoute
+        } else {
+            return uriTypeDict.get(key: uri,defaultValue: routeNotFound)
+        }
     }
     
     func addDynamicRoutes() {

--- a/SwiftHTTPServer/Router.swift
+++ b/SwiftHTTPServer/Router.swift
@@ -1,7 +1,6 @@
 class Router {
     var uri: String?
     var uriTypeDict = Dictionary<String,Route>()
-    let method = HTTPMethods(rawValue: "GET")
     var routeNotFound = NotFoundRoute(allowedMethods: [.Get, .Options])
     
     init(uri: String, method: String,body: String?) {

--- a/SwiftHTTPServer/Router.swift
+++ b/SwiftHTTPServer/Router.swift
@@ -1,23 +1,24 @@
 class Router {
     var uri: String?
     var uriTypeDict = Dictionary<String,Route>()
-    var routeNotFound = NotFoundRoute(allowedMethods: "GET,OPTIONS")
+    let method = HTTPMethods(rawValue: "GET")
+    var routeNotFound = NotFoundRoute(allowedMethods: [.Get, .Options])
     
     init(uri: String, method: String,body: String?) {
         self.uri = uri
     }
     
     func initializeRouterDict() {
-        uriTypeDict["/method_options"]  = BasicRoute(allowedMethods: "GET,OPTIONS,HEAD,POST,PUT,DELETE")
-        uriTypeDict["/method_options2"] = BasicRoute(allowedMethods: "GET,OPTIONS")
-        uriTypeDict["/"] = DirectoryListRoute(allowedMethods: "GET, OPTIONS")
-        uriTypeDict["/form"] = FormRoute(allowedMethods: "GET,OPTIONS,PUT,POST,DELETE")
-        uriTypeDict["/parameters"] = ParameterRoute(allowedMethods: "GET,OPTIONS")
-        uriTypeDict["/redirect"] = RedirectRoute(allowedMethods: "GET,OPTIONS,REDIRECT")
-        uriTypeDict["/file1"] = FileServingRoute(allowedMethods: "GET,OPTIONS")
-        uriTypeDict["/text-file.txt"] = FileServingRoute(allowedMethods: "GET,OPTIONS")
-        uriTypeDict["/image.jpeg"] = FileServingRoute(allowedMethods: "GET,OPTIONS")
-        uriTypeDict["/logs"] = BasicAuthRoute(allowedMethods: "GET")
+        uriTypeDict["/method_options"]  = BasicRoute(allowedMethods: [.Get, .Options, .Head, .Post, .Put, .Delete])
+        uriTypeDict["/method_options2"] = BasicRoute(allowedMethods: [.Get, .Options])
+        uriTypeDict["/"] = DirectoryListRoute(allowedMethods: [.Get, .Options])
+        uriTypeDict["/form"] = FormRoute(allowedMethods: [.Get, .Options, .Put, .Post, .Delete])
+        uriTypeDict["/parameters"] = ParameterRoute(allowedMethods: [.Get, .Options])
+        uriTypeDict["/redirect"] = RedirectRoute(allowedMethods: [.Get, .Options, .Redirect])
+        uriTypeDict["/file1"] = FileServingRoute(allowedMethods: [.Get, .Options])
+        uriTypeDict["/text-file.txt"] = FileServingRoute(allowedMethods: [.Get, .Options])
+        uriTypeDict["/image.jpeg"] = FileServingRoute(allowedMethods: [.Get, .Options])
+        uriTypeDict["/logs"] = BasicAuthRoute(allowedMethods: [.Get])
         addDynamicRoutes()
     }
     
@@ -30,7 +31,7 @@ class Router {
         
         
         for file in fileNames {
-            uriTypeDict["/\(file)"] = FileServingRoute(allowedMethods: "GET,OPTIONS,PATCH")
+            uriTypeDict["/\(file)"] = FileServingRoute(allowedMethods: [.Get, .Options, .Patch])
         }
     }
     

--- a/SwiftHTTPServerTests/BasicAuthRouteTests.swift
+++ b/SwiftHTTPServerTests/BasicAuthRouteTests.swift
@@ -42,7 +42,7 @@ class BasicAuthRouteTests: XCTestCase {
         let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let requestHeaders = Dictionary<String,String>()
         
-        let responseBody = authRoute.getResponseBody(uri: "/logs", method: "GET", requestHeaders: requestHeaders, requestBody: "")
+        let responseBody = authRoute.getResponseBody(uri: "/logs", method: .Get, requestHeaders: requestHeaders, requestBody: "")
         
         XCTAssertEqual([UInt8](), responseBody)
     }
@@ -51,8 +51,8 @@ class BasicAuthRouteTests: XCTestCase {
         let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let requestHeaders = Dictionary<String,String>()
         
-        authRoute.getResponseBody(uri: "/logs", method: "GET", requestHeaders: requestHeaders, requestBody: "")
-        let statusCode = authRoute.getResponseStatusCode(method: "GET")
+        authRoute.getResponseBody(uri: "/logs", method: .Get, requestHeaders: requestHeaders, requestBody: "")
+        let statusCode = authRoute.getResponseStatusCode(method: .Get)
         
         XCTAssertEqual("401", statusCode)
     }
@@ -61,7 +61,7 @@ class BasicAuthRouteTests: XCTestCase {
         let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let requestHeaders: Dictionary<String,String> = ["Authorization":"auth VG9tIE1jR2VlIFJ1bGVz"]
         
-        let responseBody = authRoute.getResponseBody(uri: "/Logs", method: "GET", requestHeaders: requestHeaders, requestBody: "")
+        let responseBody = authRoute.getResponseBody(uri: "/Logs", method: .Get, requestHeaders: requestHeaders, requestBody: "")
         
         XCTAssertEqual([UInt8](), responseBody)
     }
@@ -73,7 +73,7 @@ class BasicAuthRouteTests: XCTestCase {
         logger.log(string: "GET /method_options HTTP/1.1")
         let requestHeaders: Dictionary<String,String> = ["Authorization":"auth YWRtaW46aHVudGVyMg=="]
         
-        let responseBody = authRoute.getResponseBody(uri: "/Logs", method: "GET", requestHeaders: requestHeaders, requestBody: "")
+        let responseBody = authRoute.getResponseBody(uri: "/Logs", method: .Get, requestHeaders: requestHeaders, requestBody: "")
         
         XCTAssertNotEqual([UInt8](), responseBody)
     }
@@ -82,8 +82,8 @@ class BasicAuthRouteTests: XCTestCase {
         let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let requestHeaders: Dictionary<String,String> = ["Authorization":"auth YWRtaW46aHVudGVyMg=="]
         
-        authRoute.getResponseBody(uri: "/Logs", method: "GET", requestHeaders: requestHeaders, requestBody: "")
-        let statusCode = authRoute.getResponseStatusCode(method: "GET")
+        authRoute.getResponseBody(uri: "/Logs", method: .Get, requestHeaders: requestHeaders, requestBody: "")
+        let statusCode = authRoute.getResponseStatusCode(method: .Get)
         XCTAssertEqual("200", statusCode)
     }
     

--- a/SwiftHTTPServerTests/BasicAuthRouteTests.swift
+++ b/SwiftHTTPServerTests/BasicAuthRouteTests.swift
@@ -3,7 +3,7 @@ import XCTest
 class BasicAuthRouteTests: XCTestCase {
 
     func testDecodeBase64() {
-        let authRoute = BasicAuthRoute(allowedMethods: "GET,OPTIONS")
+        let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let encodedBase64 = "YWRtaW46aHVudGVyMg=="
         
         let decodedBase64 = authRoute.decodeBase64(base64: encodedBase64)
@@ -12,7 +12,7 @@ class BasicAuthRouteTests: XCTestCase {
     }
     
     func testGetAuthorizedWithoutHeader() {
-        let authRoute = BasicAuthRoute(allowedMethods: "GET,OPTIONS")
+        let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let requestHeaders = Dictionary<String,String>()
         
         let authorized = authRoute.getAuthorized(requestHeaders: requestHeaders)
@@ -21,7 +21,7 @@ class BasicAuthRouteTests: XCTestCase {
     }
     
     func testGetAuthorizedWithCorrectHeader() {
-        let authRoute = BasicAuthRoute(allowedMethods: "GET,OPTIONS")
+        let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let requestHeaders: Dictionary<String,String> = ["Authorization":"auth YWRtaW46aHVudGVyMg=="]
         
         let authorized = authRoute.getAuthorized(requestHeaders: requestHeaders)
@@ -30,7 +30,7 @@ class BasicAuthRouteTests: XCTestCase {
     }
     
     func testGetAuthorizedWithIncorrectHeader() {
-        let authRoute = BasicAuthRoute(allowedMethods: "GET,OPTIONS")
+        let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let requestHeaders: Dictionary<String,String> = ["Authorization":"auth VG9tIE1jR2VlIFJ1bGVz"]
         
         let authorized = authRoute.getAuthorized(requestHeaders: requestHeaders)
@@ -39,7 +39,7 @@ class BasicAuthRouteTests: XCTestCase {
     }
     
     func testGetResponseBodyWithOutCredentials() {
-        let authRoute = BasicAuthRoute(allowedMethods: "GET,OPTIONS")
+        let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let requestHeaders = Dictionary<String,String>()
         
         let responseBody = authRoute.getResponseBody(uri: "/logs", method: "GET", requestHeaders: requestHeaders, requestBody: "")
@@ -48,7 +48,7 @@ class BasicAuthRouteTests: XCTestCase {
     }
     
     func testGetStatusCodeWithoutCredentials() {
-        let authRoute = BasicAuthRoute(allowedMethods: "GET,OPTIONS")
+        let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let requestHeaders = Dictionary<String,String>()
         
         authRoute.getResponseBody(uri: "/logs", method: "GET", requestHeaders: requestHeaders, requestBody: "")
@@ -58,7 +58,7 @@ class BasicAuthRouteTests: XCTestCase {
     }
     
     func testGetReponseBodyWithIncorrectCredentials() {
-        let authRoute = BasicAuthRoute(allowedMethods: "GET,OPTIONS")
+        let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let requestHeaders: Dictionary<String,String> = ["Authorization":"auth VG9tIE1jR2VlIFJ1bGVz"]
         
         let responseBody = authRoute.getResponseBody(uri: "/Logs", method: "GET", requestHeaders: requestHeaders, requestBody: "")
@@ -67,7 +67,7 @@ class BasicAuthRouteTests: XCTestCase {
     }
     
     func testGetReponseBodyWithCorrectCredentials() {
-        let authRoute = BasicAuthRoute(allowedMethods: "GET,OPTIONS")
+        let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         Configuration.logDirectory = "."
         let logger = Logger(fileName: "/log.txt",pathToDir: Configuration.logDirectory)
         logger.log(string: "GET /method_options HTTP/1.1")
@@ -79,7 +79,7 @@ class BasicAuthRouteTests: XCTestCase {
     }
     
     func testGetStatusCodeWithCorrectCredentials() {
-        let authRoute = BasicAuthRoute(allowedMethods: "GET,OPTIONS")
+        let authRoute = BasicAuthRoute(allowedMethods: [.Get, .Options])
         let requestHeaders: Dictionary<String,String> = ["Authorization":"auth YWRtaW46aHVudGVyMg=="]
         
         authRoute.getResponseBody(uri: "/Logs", method: "GET", requestHeaders: requestHeaders, requestBody: "")

--- a/SwiftHTTPServerTests/BasicRouteTests.swift
+++ b/SwiftHTTPServerTests/BasicRouteTests.swift
@@ -3,25 +3,25 @@ import XCTest
 class BasicRouteTests: XCTestCase {
     
     func testBasicRouteInitializedWithAllowedMethods() {
-        let route = BasicRoute(allowedMethods: "GET,OPTIONS")
-        let expectedMethods = ["GET","OPTIONS"]
-        XCTAssertEqual(expectedMethods, route.allowedMethods!)
+        let route = BasicRoute(allowedMethods: [.Get, .Options])
+        let expectedMethods: [HTTPMethods] = [.Get, .Options]
+        XCTAssertEqual(expectedMethods, route.allowedMethods)
     }
     
     func testGetAllowedMethods() {
-        let route = BasicRoute(allowedMethods: "GET,OPTIONS,POST")
-        let expectedMethods = ["GET","OPTIONS","POST"]
+        let route = BasicRoute(allowedMethods: [.Get, .Options, .Post])
+        let expectedMethods: [HTTPMethods] = [.Get, .Options, .Post]
         XCTAssertEqual(expectedMethods, route.getAllowedMethods())
     }
     
     func testIsAllowedMethod() {
-        let route = BasicRoute(allowedMethods: "GET,OPTIONS,POST")
+        let route = BasicRoute(allowedMethods: [.Get, .Options, .Post])
         
         XCTAssert(route.isAllowedMethod(method: "GET"))
     }
     
     func testGetBody() {
-        let route = BasicRoute(allowedMethods: "GET,OPTIONS")
+        let route = BasicRoute(allowedMethods: [.Get, .Options])
         let expectedResponseBody = ("GET for /testing123")
         
         let responseBody = route.getResponseBody(uri: "/testing123", method: "GET", requestHeaders: Dictionary<String,String>(), requestBody: nil)
@@ -31,10 +31,10 @@ class BasicRouteTests: XCTestCase {
     }
     
     func testGetResponseHeaders() {
-        let route = BasicRoute(allowedMethods: "GET,OPTIONS")
+        let route = BasicRoute(allowedMethods: [.Get, .Options])
         var expectedHeaders = Dictionary<String,String>()
         expectedHeaders["Content-Type"] = "text/html"
-        expectedHeaders["Allow"] = "GET,OPTIONS"
+        expectedHeaders["Allow"] = "GET, OPTIONS"
         
         let headers = route.getResponseHeaders(uri: "/yolo", method: "OPTIONS", requestBody: nil)
         
@@ -43,21 +43,21 @@ class BasicRouteTests: XCTestCase {
     }
     
     func testGetResponseStatusCode() {
-        let route = BasicRoute(allowedMethods: "GET,OPTIONS")
+        let route = BasicRoute(allowedMethods: [.Get, .Options])
         let expectedResponseCode = "200"
         
         XCTAssertEqual(expectedResponseCode, route.getResponseStatusCode(method: "GET"))
     }
     
     func testGetResponseStatusCodeNotAllowed() {
-        let route = BasicRoute(allowedMethods:"GET")
+        let route = BasicRoute(allowedMethods:[.Get])
         let expectedResponseCode = "405"
         
         XCTAssertEqual(expectedResponseCode, route.getResponseStatusCode(method: "POST"))
     }
     
     func testGetByteArrayFromString() {
-        let route = BasicRoute(allowedMethods: "GET,OPTIONS")
+        let route = BasicRoute(allowedMethods: [.Get, .Options])
         let string = "aaaa"
         let expectedByteArray: [UInt8] = [97, 97, 97, 97, 0]
         
@@ -65,12 +65,31 @@ class BasicRouteTests: XCTestCase {
     }
     
     func testRemoveNullBytesFromByteArray() {
-        let route = BasicRoute(allowedMethods: "GET")
+        let route = BasicRoute(allowedMethods: [.Get])
         let byteArray: [UInt8] = [0,1,2,0,4]
         
         let expectedResults: [UInt8] = [1,2,4]
         
         XCTAssertEqual(route.removeNullBytes(byteArray: byteArray), expectedResults)
+    }
+    
+    func testContains() {
+        let allowedMethods: [HTTPMethods] = [.Get, .Put, .Head]
+        
+        let route = BasicRoute(allowedMethods: allowedMethods)
+        
+        XCTAssertTrue(route.contains(allowedMethods: allowedMethods, method: "GET"))
+    }
+    
+    func testJoined() {
+        func testContains() {
+            let allowedMethods: [HTTPMethods] = [.Get, .Put, .Head]
+            
+            let route = BasicRoute(allowedMethods: allowedMethods)
+            let expectedResults = "GET, PUT, HEAD"
+            
+            XCTAssertEqual(route.joined(allowedMethods: allowedMethods, separator: ","), expectedResults)
+        }
     }
 
 }

--- a/SwiftHTTPServerTests/BasicRouteTests.swift
+++ b/SwiftHTTPServerTests/BasicRouteTests.swift
@@ -34,7 +34,7 @@ class BasicRouteTests: XCTestCase {
         let route = BasicRoute(allowedMethods: [.Get, .Options])
         var expectedHeaders = Dictionary<String,String>()
         expectedHeaders["Content-Type"] = "text/html"
-        expectedHeaders["Allow"] = "GET, OPTIONS"
+        expectedHeaders["Allow"] = "GET,OPTIONS"
         
         let headers = route.getResponseHeaders(uri: "/yolo", method: "OPTIONS", requestBody: nil)
         

--- a/SwiftHTTPServerTests/BasicRouteTests.swift
+++ b/SwiftHTTPServerTests/BasicRouteTests.swift
@@ -17,14 +17,14 @@ class BasicRouteTests: XCTestCase {
     func testIsAllowedMethod() {
         let route = BasicRoute(allowedMethods: [.Get, .Options, .Post])
         
-        XCTAssert(route.isAllowedMethod(method: "GET"))
+        XCTAssert(route.isAllowedMethod(method: .Get))
     }
     
     func testGetBody() {
         let route = BasicRoute(allowedMethods: [.Get, .Options])
         let expectedResponseBody = ("GET for /testing123")
         
-        let responseBody = route.getResponseBody(uri: "/testing123", method: "GET", requestHeaders: Dictionary<String,String>(), requestBody: nil)
+        let responseBody = route.getResponseBody(uri: "/testing123", method: .Get, requestHeaders: Dictionary<String,String>(), requestBody: nil)
         let responseBodyString = NSString(bytes: responseBody,length: responseBody.count, encoding: NSUTF8StringEncoding)
         
         XCTAssertEqual(responseBodyString, expectedResponseBody)
@@ -36,7 +36,7 @@ class BasicRouteTests: XCTestCase {
         expectedHeaders["Content-Type"] = "text/html"
         expectedHeaders["Allow"] = "GET,OPTIONS"
         
-        let headers = route.getResponseHeaders(uri: "/yolo", method: "OPTIONS", requestBody: nil)
+        let headers = route.getResponseHeaders(uri: "/yolo", method: .Options, requestBody: nil)
         
         XCTAssertEqual(expectedHeaders, headers)
         
@@ -46,14 +46,14 @@ class BasicRouteTests: XCTestCase {
         let route = BasicRoute(allowedMethods: [.Get, .Options])
         let expectedResponseCode = "200"
         
-        XCTAssertEqual(expectedResponseCode, route.getResponseStatusCode(method: "GET"))
+        XCTAssertEqual(expectedResponseCode, route.getResponseStatusCode(method: .Get))
     }
     
     func testGetResponseStatusCodeNotAllowed() {
         let route = BasicRoute(allowedMethods:[.Get])
         let expectedResponseCode = "405"
         
-        XCTAssertEqual(expectedResponseCode, route.getResponseStatusCode(method: "POST"))
+        XCTAssertEqual(expectedResponseCode, route.getResponseStatusCode(method: .Post))
     }
     
     func testGetByteArrayFromString() {
@@ -78,7 +78,7 @@ class BasicRouteTests: XCTestCase {
         
         let route = BasicRoute(allowedMethods: allowedMethods)
         
-        XCTAssertTrue(route.contains(allowedMethods: allowedMethods, method: "GET"))
+        XCTAssertTrue(route.contains(allowedMethods: allowedMethods, method: .Get))
     }
     
     func testJoined() {

--- a/SwiftHTTPServerTests/DirectoryListRouteTests.swift
+++ b/SwiftHTTPServerTests/DirectoryListRouteTests.swift
@@ -37,7 +37,7 @@ class DirectoryListRouteTests: XCTestCase {
     func testGetResponseBodyNoElements(){
         mkdir("./testing123",0777)
         Configuration.publicDirectory = workingDir! + "testing123/"
-        let response = directoryListRoute.getResponseBody(uri: "/YOLO", method: "GET", requestHeaders: Dictionary<String,String>(), requestBody: "")
+        let response = directoryListRoute.getResponseBody(uri: "/YOLO", method: .Get, requestHeaders: Dictionary<String,String>(), requestBody: "")
         let responseString = NSString(bytes: response,length: response.count, encoding: NSUTF8StringEncoding)
         XCTAssert(responseString!.contains("<ul></ul>"))
         rmdir("./testing123")
@@ -45,7 +45,7 @@ class DirectoryListRouteTests: XCTestCase {
     
     func testGetResponseBodyWithElements(){
         Configuration.publicDirectory = workingDir!
-        let response = directoryListRoute.getResponseBody(uri: "/YOLO", method: "GET", requestHeaders: Dictionary<String,String>(), requestBody: "")
+        let response = directoryListRoute.getResponseBody(uri: "/YOLO", method: .Get, requestHeaders: Dictionary<String,String>(), requestBody: "")
         let responseString = NSString(bytes: response,length: response.count, encoding: NSUTF8StringEncoding)
         XCTAssertFalse(responseString!.contains("<ul></ul>"))
     }
@@ -54,7 +54,7 @@ class DirectoryListRouteTests: XCTestCase {
         Configuration.publicDirectory = workingDir!
         fopen("./Show.txt","w")
         
-        let response = directoryListRoute.getResponseBody(uri: "/YOLO", method: "GET", requestHeaders: Dictionary<String,String>(), requestBody: "")
+        let response = directoryListRoute.getResponseBody(uri: "/YOLO", method: .Get, requestHeaders: Dictionary<String,String>(), requestBody: "")
         let responseString = NSString(bytes: response,length: response.count, encoding: NSUTF8StringEncoding)
         
         XCTAssert(responseString!.contains("Show.txt"))
@@ -65,7 +65,7 @@ class DirectoryListRouteTests: XCTestCase {
     func testGetResponseBodyNoDots(){
         Configuration.publicDirectory = workingDir!
         fopen("./.noShow.txt","w")
-        let response = directoryListRoute.getResponseBody(uri: "/YOLO", method: "GET", requestHeaders: Dictionary<String,String>(), requestBody: "")
+        let response = directoryListRoute.getResponseBody(uri: "/YOLO", method: .Get, requestHeaders: Dictionary<String,String>(), requestBody: "")
         let responseString = NSString(bytes: response,length: response.count, encoding: NSUTF8StringEncoding)
         
         XCTAssertFalse(responseString!.contains("noShow.txt"))

--- a/SwiftHTTPServerTests/DirectoryListRouteTests.swift
+++ b/SwiftHTTPServerTests/DirectoryListRouteTests.swift
@@ -8,14 +8,14 @@ import XCTest
 
 class DirectoryListRouteTests: XCTestCase {
 
-    var directoryListRoute = DirectoryListRoute(allowedMethods:"GET,OPTIONS")
+    var directoryListRoute = DirectoryListRoute(allowedMethods: [.Get, .Options])
     var currentDir: UnsafeMutablePointer<Int8>?
     var workingDir: String?
 
 
     override func setUp() {
         super.setUp()
-        directoryListRoute = DirectoryListRoute(allowedMethods:"GET,OPTIONS")
+        directoryListRoute = DirectoryListRoute(allowedMethods: [.Get, .Options])
         currentDir = UnsafeMutablePointer<Int8>(allocatingCapacity: 1000)
         workingDir = String(cString: getcwd(currentDir, 1000)) + "/"
     }

--- a/SwiftHTTPServerTests/FileOperationsTests.swift
+++ b/SwiftHTTPServerTests/FileOperationsTests.swift
@@ -78,7 +78,7 @@ class FormDataTests: XCTestCase {
     
     func testWriteFormAction() {
         
-        fileOperations!.formAction(method: "POST", body: "TESTING")
+        fileOperations!.formAction(method: .Post , body: "TESTING")
         
         let readText = LocalRead()
         
@@ -93,7 +93,7 @@ class FormDataTests: XCTestCase {
         
         XCTAssert(fileManager.fileExists(atPath: filePath))
         
-        fileOperations!.formAction(method: "DELETE", body: "")
+        fileOperations!.formAction(method: .Delete, body: "")
         
         XCTAssertFalse(fileManager.fileExists(atPath: filePath))
     }

--- a/SwiftHTTPServerTests/FileServingRouteTests.swift
+++ b/SwiftHTTPServerTests/FileServingRouteTests.swift
@@ -5,7 +5,7 @@ class FileServingRouteTests: XCTestCase {
     func testGetHeaders() {
         let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         let expectedHeaders: Dictionary<String,String> = [:]
-        let headers = fileServingRoute.getResponseHeaders(uri: "/blah", method: "GET", requestBody: "")
+        let headers = fileServingRoute.getResponseHeaders(uri: "/blah", method: .Get, requestBody: "")
         
         XCTAssertEqual(expectedHeaders, headers)
     }
@@ -13,24 +13,24 @@ class FileServingRouteTests: XCTestCase {
     func testGetStatusCodeAfterPartialRequest() {
         let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         let requestHeaders: Dictionary<String,String> = ["Range": "bytes=0-1"]
-        fileServingRoute.getResponseBody(uri: "/blah", method: "GET", requestHeaders: requestHeaders, requestBody: "")
+        fileServingRoute.getResponseBody(uri: "/blah", method: .Get, requestHeaders: requestHeaders, requestBody: "")
         
-        XCTAssertEqual("206", fileServingRoute.getResponseStatusCode(method: "GET"))
+        XCTAssertEqual("206", fileServingRoute.getResponseStatusCode(method: .Get))
     }
     
     func testGetStatusCodeErrorAfterInvalidPartialRequest() {
         let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         let requestHeaders: Dictionary<String,String> = ["Range": "bytes=30-1"]
-        fileServingRoute.getResponseBody(uri: "/blah", method: "GET", requestHeaders: requestHeaders, requestBody: "")
+        fileServingRoute.getResponseBody(uri: "/blah", method: .Get, requestHeaders: requestHeaders, requestBody: "")
         
-        XCTAssertEqual("416", fileServingRoute.getResponseStatusCode(method: "GET"))
+        XCTAssertEqual("416", fileServingRoute.getResponseStatusCode(method: .Get))
     }
     
     func testGetStatusCodeWithoutPartialRequest() {
         let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
-        fileServingRoute.getResponseBody(uri: "/blah", method: "GET", requestHeaders: Dictionary<String,String>(), requestBody: "")
+        fileServingRoute.getResponseBody(uri: "/blah", method: .Get, requestHeaders: Dictionary<String,String>(), requestBody: "")
         
-        XCTAssertEqual("200", fileServingRoute.getResponseStatusCode(method: "GET"))
+        XCTAssertEqual("200", fileServingRoute.getResponseStatusCode(method: .Get))
     }
     
     func testGetRangeStart() {
@@ -90,9 +90,9 @@ class FileServingRouteTests: XCTestCase {
     func testGetStatusCodeAfterPatchRequest() {
         let fileServingRoute = FileServingRoute(allowedMethods: [.Get, .Patch])
         let requestHeaders: Dictionary<String,String> = ["If-Match": "12345"]
-        fileServingRoute.getResponseBody(uri: "/blah", method: "PATCH", requestHeaders: requestHeaders, requestBody: "")
+        fileServingRoute.getResponseBody(uri: "/blah", method: .Patch, requestHeaders: requestHeaders, requestBody: "")
         
-        XCTAssertEqual("204", fileServingRoute.getResponseStatusCode(method: "PATCH"))
+        XCTAssertEqual("204", fileServingRoute.getResponseStatusCode(method: .Patch))
     }
     
     func testGetETagHeaderAfterPatchRequest() {
@@ -100,9 +100,9 @@ class FileServingRouteTests: XCTestCase {
         let requestHeaders: Dictionary<String,String> = ["If-Match": "12345"]
         let expectedResponseHeaders: Dictionary<String,String> = ["ETag": "12345"]
         
-        fileServingRoute.getResponseBody(uri: "/blah", method: "PATCH", requestHeaders: requestHeaders, requestBody: "")
+        fileServingRoute.getResponseBody(uri: "/blah", method: .Patch, requestHeaders: requestHeaders, requestBody: "")
         
-        let responseHeaders = fileServingRoute.getResponseHeaders(uri: "/blah", method: "PATCH", requestBody: "")
+        let responseHeaders = fileServingRoute.getResponseHeaders(uri: "/blah", method: .Patch, requestBody: "")
         
         
         XCTAssertEqual(expectedResponseHeaders, responseHeaders)

--- a/SwiftHTTPServerTests/FileServingRouteTests.swift
+++ b/SwiftHTTPServerTests/FileServingRouteTests.swift
@@ -3,7 +3,7 @@ import XCTest
 class FileServingRouteTests: XCTestCase {
     
     func testGetHeaders() {
-        let fileServingRoute = FileServingRoute(allowedMethods: "GET")
+        let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         let expectedHeaders: Dictionary<String,String> = [:]
         let headers = fileServingRoute.getResponseHeaders(uri: "/blah", method: "GET", requestBody: "")
         
@@ -11,7 +11,7 @@ class FileServingRouteTests: XCTestCase {
     }
     
     func testGetStatusCodeAfterPartialRequest() {
-        let fileServingRoute = FileServingRoute(allowedMethods: "GET")
+        let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         let requestHeaders: Dictionary<String,String> = ["Range": "bytes=0-1"]
         fileServingRoute.getResponseBody(uri: "/blah", method: "GET", requestHeaders: requestHeaders, requestBody: "")
         
@@ -19,7 +19,7 @@ class FileServingRouteTests: XCTestCase {
     }
     
     func testGetStatusCodeErrorAfterInvalidPartialRequest() {
-        let fileServingRoute = FileServingRoute(allowedMethods: "GET")
+        let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         let requestHeaders: Dictionary<String,String> = ["Range": "bytes=30-1"]
         fileServingRoute.getResponseBody(uri: "/blah", method: "GET", requestHeaders: requestHeaders, requestBody: "")
         
@@ -27,14 +27,14 @@ class FileServingRouteTests: XCTestCase {
     }
     
     func testGetStatusCodeWithoutPartialRequest() {
-        let fileServingRoute = FileServingRoute(allowedMethods: "GET")
+        let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         fileServingRoute.getResponseBody(uri: "/blah", method: "GET", requestHeaders: Dictionary<String,String>(), requestBody: "")
         
         XCTAssertEqual("200", fileServingRoute.getResponseStatusCode(method: "GET"))
     }
     
     func testGetRangeStart() {
-        let fileServingRoute = FileServingRoute(allowedMethods: "GET")
+        let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         let range = "bytes=0-1"
         let expectedStartIndex = 0
         
@@ -44,7 +44,7 @@ class FileServingRouteTests: XCTestCase {
     }
     
     func testGetRangeStartNoVal() {
-        let fileServingRoute = FileServingRoute(allowedMethods: "GET")
+        let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         let range = "bytes=-1"
         let expectedStartIndex = 0
         
@@ -54,7 +54,7 @@ class FileServingRouteTests: XCTestCase {
     }
     
     func testGetRangeEnd() {
-        let fileServingRoute = FileServingRoute(allowedMethods: "GET")
+        let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         let range = "bytes=0-1"
         let expectedendIndex = 1
         
@@ -64,7 +64,7 @@ class FileServingRouteTests: XCTestCase {
     }
     
     func testGetRangeEndNoVal() {
-        let fileServingRoute = FileServingRoute(allowedMethods: "GET")
+        let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         let range = "bytes=0-"
         let expectedEndIndex = -2
         
@@ -74,7 +74,7 @@ class FileServingRouteTests: XCTestCase {
     }
     
     func testGetRangeStartEndNoVals() {
-        let fileServingRoute = FileServingRoute(allowedMethods: "GET")
+        let fileServingRoute = FileServingRoute(allowedMethods: [.Get])
         let range = "bytes=-"
         let expectedStartIndex = 0
         let expectedEndIndex = -2
@@ -88,7 +88,7 @@ class FileServingRouteTests: XCTestCase {
     }
     
     func testGetStatusCodeAfterPatchRequest() {
-        let fileServingRoute = FileServingRoute(allowedMethods: "GET,PATCH")
+        let fileServingRoute = FileServingRoute(allowedMethods: [.Get, .Patch])
         let requestHeaders: Dictionary<String,String> = ["If-Match": "12345"]
         fileServingRoute.getResponseBody(uri: "/blah", method: "PATCH", requestHeaders: requestHeaders, requestBody: "")
         
@@ -96,7 +96,7 @@ class FileServingRouteTests: XCTestCase {
     }
     
     func testGetETagHeaderAfterPatchRequest() {
-        let fileServingRoute = FileServingRoute(allowedMethods: "GET,PATCH")
+        let fileServingRoute = FileServingRoute(allowedMethods: [.Get, .Patch])
         let requestHeaders: Dictionary<String,String> = ["If-Match": "12345"]
         let expectedResponseHeaders: Dictionary<String,String> = ["ETag": "12345"]
         

--- a/SwiftHTTPServerTests/FormRouteTests.swift
+++ b/SwiftHTTPServerTests/FormRouteTests.swift
@@ -3,7 +3,7 @@ import XCTest
 class FormRouteTests: XCTestCase {
     let fileManager = NSFileManager()
     let file = "testRoute.txt"
-    var formRoute = FormRoute(allowedMethods: "GET,OPTIONS,POST,PUT,DELETE")
+    var formRoute = FormRoute(allowedMethods: [.Get, .Options, .Post, .Put, .Delete])
     
     override func tearDown() {
         super.tearDown()
@@ -20,7 +20,7 @@ class FormRouteTests: XCTestCase {
     }
     
     func testGetResponseBodyMethodNotAllowed() {
-        formRoute = FormRoute(allowedMethods: "GET,OPTIONS,POST,PUT")
+        formRoute = FormRoute(allowedMethods: [.Get, .Options, .Post, .Put])
         
         let expectedResults = "405 - Method Not Allowed"
         

--- a/SwiftHTTPServerTests/FormRouteTests.swift
+++ b/SwiftHTTPServerTests/FormRouteTests.swift
@@ -7,13 +7,13 @@ class FormRouteTests: XCTestCase {
     
     override func tearDown() {
         super.tearDown()
-        formRoute.getResponseBody(uri: "/form", method: "DELETE", requestHeaders: Dictionary<String,String>(), requestBody: "")
+        formRoute.getResponseBody(uri: "/form", method: .Delete, requestHeaders: Dictionary<String,String>(), requestBody: "")
     }
     
     func testGetResponseBody() {
-        formRoute.getResponseBody(uri: "/form", method: "POST", requestHeaders: Dictionary<String,String>(), requestBody:"Howdy")
+        formRoute.getResponseBody(uri: "/form", method: .Post, requestHeaders: Dictionary<String,String>(), requestBody:"Howdy")
         
-        let fileContents = formRoute.getResponseBody(uri: "/form", method: "GET", requestHeaders: Dictionary<String,String>(), requestBody:"")
+        let fileContents = formRoute.getResponseBody(uri: "/form", method: .Get , requestHeaders: Dictionary<String,String>(), requestBody:"")
         let fileContentsString = NSString(bytes: fileContents,length: fileContents.count, encoding: NSUTF8StringEncoding)
 
         XCTAssertEqual("Howdy",fileContentsString)
@@ -24,7 +24,7 @@ class FormRouteTests: XCTestCase {
         
         let expectedResults = "405 - Method Not Allowed"
         
-        let fileContents = formRoute.getResponseBody(uri: "/form", method: "DELETE", requestHeaders: Dictionary<String,String>(), requestBody: "")
+        let fileContents = formRoute.getResponseBody(uri: "/form", method: .Delete, requestHeaders: Dictionary<String,String>(), requestBody: "")
         let fileContentsString = NSString(bytes: fileContents,length: fileContents.count, encoding: NSUTF8StringEncoding)
         
         XCTAssertEqual(expectedResults, fileContentsString)

--- a/SwiftHTTPServerTests/NotAllowedRouteTests.swift
+++ b/SwiftHTTPServerTests/NotAllowedRouteTests.swift
@@ -1,10 +1,10 @@
 import XCTest
 
-class NotFoundRouteTests: XCTestCase {
-
+class NotAllowedRouteTests: XCTestCase {
+    
     func testGetBody() {
-        let route = NotFoundRoute(allowedMethods: [.Get])
-        let expectedResponseBody = ("404 - Not Found")
+        let route = NotAllowedRoute(allowedMethods: [.Get])
+        let expectedResponseBody = ("405 - Method Not Allowed")
         
         let responseBody = route.getResponseBody(uri: "/testing123", method: .Get, requestHeaders: Dictionary<String,String>(), requestBody: nil)
         let responseString = NSString(bytes: responseBody,length: responseBody.count, encoding: NSUTF8StringEncoding)
@@ -13,10 +13,10 @@ class NotFoundRouteTests: XCTestCase {
     }
     
     func testGetResponseStatusCode() {
-        let route = NotFoundRoute(allowedMethods: [.Get, .Options])
-        let expectedResponseCode = "404"
+        let route = NotAllowedRoute(allowedMethods: [.Get, .Options])
+        let expectedResponseCode = "405"
         
         XCTAssertEqual(expectedResponseCode, route.getResponseStatusCode(method: .Get))
     }
-
+    
 }

--- a/SwiftHTTPServerTests/NotFoundRouteTests.swift
+++ b/SwiftHTTPServerTests/NotFoundRouteTests.swift
@@ -3,7 +3,7 @@ import XCTest
 class NotFoundRouteTests: XCTestCase {
 
     func testGetBody() {
-        let route = NotFoundRoute(allowedMethods: "GET")
+        let route = NotFoundRoute(allowedMethods: [.Get])
         let expectedResponseBody = ("404 - Not Found")
         
         let responseBody = route.getResponseBody(uri: "/testing123", method: "GET", requestHeaders: Dictionary<String,String>(), requestBody: nil)
@@ -13,7 +13,7 @@ class NotFoundRouteTests: XCTestCase {
     }
     
     func testGetResponseStatusCode() {
-        let route = NotFoundRoute(allowedMethods: "GET,OPTIONS")
+        let route = NotFoundRoute(allowedMethods: [.Get, .Options])
         let expectedResponseCode = "404"
         
         XCTAssertEqual(expectedResponseCode, route.getResponseStatusCode(method: "_"))

--- a/SwiftHTTPServerTests/ParameterRouteTests.swift
+++ b/SwiftHTTPServerTests/ParameterRouteTests.swift
@@ -4,10 +4,10 @@ class ParameterRouteTests: XCTestCase {
 
     let URIWithParams = "/parameters?variable_1=Operators%20%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F&variable_2=stuff"
     
-    let paramsRoute = ParameterRoute(allowedMethods: "GET,OPTIONS")
+    let paramsRoute = ParameterRoute(allowedMethods: [.Get, .Options])
     
     func testGetAllowedMethods() {
-        let expectedAllowedMethods = ["GET","OPTIONS"]
+        let expectedAllowedMethods: [HTTPMethods] = [.Get, .Options]
         let allowedMethods = paramsRoute.getAllowedMethods()
         
         XCTAssertEqual(expectedAllowedMethods, allowedMethods)
@@ -20,7 +20,7 @@ class ParameterRouteTests: XCTestCase {
     func testExtensionOfBasicRouteReturnsCorrectOptionsHeader() {
         let headers = paramsRoute.getResponseHeaders(uri: "/_", method: "OPTIONS", requestBody: "")
         
-        XCTAssertEqual(headers["Allow"],"GET,OPTIONS")
+        XCTAssertEqual(headers["Allow"],"GET, OPTIONS")
     }
 
     func testGetResponseBody() {

--- a/SwiftHTTPServerTests/ParameterRouteTests.swift
+++ b/SwiftHTTPServerTests/ParameterRouteTests.swift
@@ -20,7 +20,7 @@ class ParameterRouteTests: XCTestCase {
     func testExtensionOfBasicRouteReturnsCorrectOptionsHeader() {
         let headers = paramsRoute.getResponseHeaders(uri: "/_", method: "OPTIONS", requestBody: "")
         
-        XCTAssertEqual(headers["Allow"],"GET, OPTIONS")
+        XCTAssertEqual(headers["Allow"],"GET,OPTIONS")
     }
 
     func testGetResponseBody() {

--- a/SwiftHTTPServerTests/ParameterRouteTests.swift
+++ b/SwiftHTTPServerTests/ParameterRouteTests.swift
@@ -14,18 +14,18 @@ class ParameterRouteTests: XCTestCase {
     }
     
     func testIsAllowedMethods() {
-        XCTAssert(paramsRoute.isAllowedMethod(method: "OPTIONS"))
+        XCTAssert(paramsRoute.isAllowedMethod(method: .Options))
     }
     
     func testExtensionOfBasicRouteReturnsCorrectOptionsHeader() {
-        let headers = paramsRoute.getResponseHeaders(uri: "/_", method: "OPTIONS", requestBody: "")
+        let headers = paramsRoute.getResponseHeaders(uri: "/_", method: .Options, requestBody: "")
         
         XCTAssertEqual(headers["Allow"],"GET,OPTIONS")
     }
 
     func testGetResponseBody() {
         let expectedResults = "variable_1 = Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"? variable_2 = stuff"
-        let responseBody = paramsRoute.getResponseBody(uri: URIWithParams, method: "GET", requestHeaders: Dictionary<String,String>(), requestBody: "")
+        let responseBody = paramsRoute.getResponseBody(uri: URIWithParams, method: .Get, requestHeaders: Dictionary<String,String>(), requestBody: "")
         let responseBodyString = NSString(bytes: responseBody,length: responseBody.count, encoding: NSUTF8StringEncoding)
         XCTAssertEqual(responseBodyString, expectedResults)
     }

--- a/SwiftHTTPServerTests/RedirectRouteTests.swift
+++ b/SwiftHTTPServerTests/RedirectRouteTests.swift
@@ -8,13 +8,13 @@ class RedirectRouteTests: XCTestCase {
     }
     
     func testGetStatusCode() {
-        let redirectRoute = RedirectRoute(allowedMethods: "GET,OPTIONS,REDIRECT")
+        let redirectRoute = RedirectRoute(allowedMethods: [.Get, .Options, .Redirect])
         
         XCTAssertEqual(redirectRoute.getResponseStatusCode(method: "REDIRECT"), "302")
     }
     
     func testGetHeaders() {
-        let redirectRoute = RedirectRoute(allowedMethods: "GET,OPTIONS,REDIRECT")
+        let redirectRoute = RedirectRoute(allowedMethods: [.Get, .Options, .Redirect])
         
         let headers = redirectRoute.getResponseHeaders(uri: "/redirect", method: "REDIRECT", requestBody: "")
         

--- a/SwiftHTTPServerTests/RedirectRouteTests.swift
+++ b/SwiftHTTPServerTests/RedirectRouteTests.swift
@@ -10,13 +10,13 @@ class RedirectRouteTests: XCTestCase {
     func testGetStatusCode() {
         let redirectRoute = RedirectRoute(allowedMethods: [.Get, .Options, .Redirect])
         
-        XCTAssertEqual(redirectRoute.getResponseStatusCode(method: "REDIRECT"), "302")
+        XCTAssertEqual(redirectRoute.getResponseStatusCode(method: .Redirect), "302")
     }
     
     func testGetHeaders() {
         let redirectRoute = RedirectRoute(allowedMethods: [.Get, .Options, .Redirect])
         
-        let headers = redirectRoute.getResponseHeaders(uri: "/redirect", method: "REDIRECT", requestBody: "")
+        let headers = redirectRoute.getResponseHeaders(uri: "/redirect", method: .Redirect, requestBody: "")
         
         XCTAssert(headers.keys.contains("Location"))
         XCTAssertEqual(headers["Location"], "http://localhost:5000/")

--- a/SwiftHTTPServerTests/RouterTests.swift
+++ b/SwiftHTTPServerTests/RouterTests.swift
@@ -15,14 +15,14 @@ class RouterTests: XCTestCase {
     func testSetRoute() {
         router.uriTypeDict = Dictionary<String,Route>()
         
-        router.setRoute(uri: "/Test", route: BasicRoute(allowedMethods: "GET,OPTIONS"))
+        router.setRoute(uri: "/Test", route: BasicRoute(allowedMethods: [.Get, .Options]))
         
         XCTAssert(router.uriTypeDict.keys.contains("/Test"))
         XCTAssert(router.uriTypeDict.count > 0)
     }
     
     func testGetRoute() {
-        let expectedRoute: Route = BasicRoute(allowedMethods: "GET,OPTIONS")
+        let expectedRoute: Route = BasicRoute(allowedMethods: [.Get, .Options])
         router = Router(uri:"/method_options2",method:"OPTIONS",body:nil)
         router.initializeRouterDict()
         

--- a/SwiftHTTPServerTests/RouterTests.swift
+++ b/SwiftHTTPServerTests/RouterTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 class RouterTests: XCTestCase {
     
-    var router = Router(uri: "/Filler",method:"FILLER",body:"FILLER")
+    var router = Router(uri: "/Filler",method:.Get,body:"FILLER")
     
     func testInitialiazeRouterDict() {
         router.uriTypeDict = Dictionary<String,Route>()
@@ -23,7 +23,7 @@ class RouterTests: XCTestCase {
     
     func testGetRoute() {
         let expectedRoute: Route = BasicRoute(allowedMethods: [.Get, .Options])
-        router = Router(uri:"/method_options2",method:"OPTIONS",body:nil)
+        router = Router(uri:"/method_options2",method: .Options,body:nil)
         router.initializeRouterDict()
         
         let route = router.getRoute()
@@ -33,7 +33,7 @@ class RouterTests: XCTestCase {
     }
     
     func testAddDynamicRoutes() {
-        router = Router(uri: "/dynamic_rotes", method:"GET",body:nil)
+        router = Router(uri: "/dynamic_rotes", method: .Options,body:nil)
         Configuration.publicDirectory = "."
         XCTAssert(router.uriTypeDict.values.count == 0)
         

--- a/SwiftHTTPServerTests/SwiftHTTPServerTests.swift
+++ b/SwiftHTTPServerTests/SwiftHTTPServerTests.swift
@@ -5,7 +5,7 @@ class SwiftHTTPServerTests: XCTestCase {
     let server = HTTPServer()
     override func setUp() {
         super.setUp()
-        Configuration.port = 5000
+        Configuration.port = 5001
         server.start()
     }
     

--- a/SwiftHTTPServerTests/SwiftSocketTests.swift
+++ b/SwiftHTTPServerTests/SwiftSocketTests.swift
@@ -7,6 +7,7 @@ class SwiftSocketTests: XCTestCase {
     
     
     func testDefaultPort() {
+        Configuration.port = 5000
         XCTAssertEqual(5000, Configuration.port)
     }
     


### PR DESCRIPTION
BasicRoute and the Route protocol now accept the allowedMethods as an array of HTTPMethods.
The Router is now initialized with the method called as an HTTPMethods instead of a string.
The Request now parses the method from a string into a HTTPMethods object, which it then passes into the router.
If the method isn't found when attempting to parse the method into an HTTPMethods, it is set to .NotFound which the router returns as a new route (NotAllowedRoute) to handle 405's
